### PR TITLE
[FIX] Add missing parameters to StoredCredential Object

### DIFF
--- a/source/Paysafe/CardPayments/StoredCredential.php
+++ b/source/Paysafe/CardPayments/StoredCredential.php
@@ -8,6 +8,8 @@ namespace Paysafe\CardPayments;
 /**
  * @property string $type
  * @property number $occurrence
+ * @property string $initialTransactionId
+ * @property string $externalInitialTransactionId
  */
 class StoredCredential extends \Paysafe\JSONObject
 {
@@ -20,6 +22,8 @@ class StoredCredential extends \Paysafe\JSONObject
         'occurrence' => array(
             'INITIAL',
             'SUBSEQUENT'
-        )
+        ),
+        'initialTransactionId' => 'string',
+        'externalInitialTransactionId' => 'string'
     );
 }


### PR DESCRIPTION
see https://developer.paysafe.com/en/cards/api/#/introduction/complex-json-objects/storedcredential